### PR TITLE
Fix compatibility typo

### DIFF
--- a/docs/getting-started/compatability.mdx
+++ b/docs/getting-started/compatability.mdx
@@ -1,7 +1,7 @@
 ---
-id: compatability
-title: Compatability
-slug: /compatability
+id: compatibility
+title: Compatibility
+slug: /compatibility
 ---
 
 If you can import it from `material-table` you can import it from `@material-table/core`. ~~This will never change.~~ Ok, we admit, that was a little bold. [Please see here for more info](breaking-changes).

--- a/sidebar.docs.js
+++ b/sidebar.docs.js
@@ -7,7 +7,7 @@ module.exports = {
         "getting-started/install",
         "getting-started/material-ui-v5",
         "getting-started/breaking-changes",
-        "getting-started/compatability",
+        "getting-started/compatibility",
         "getting-started/about",
       ],
     },


### PR DESCRIPTION
Hey, Fixing a small typo 🙂 

`compatability` -> `compatibility`