### PR TITLE
fix: use correct prop name for custom group

### DIFF
--- a/demos/group/override.mdx
+++ b/demos/group/override.mdx
@@ -36,7 +36,7 @@ function GroupingOverrideDemo() {
       data={DEMO_DATA}
       columns={DEMO_COLS.map((col) => ({
         ...col,
-        groupRender: (value) => `Test ${value}`,
+        renderGroup: (value) => `Test ${value}`,
       }))}
       options={{
         // Enabling grouping


### PR DESCRIPTION
The correct prop name I believe is `renderGroup` ?
https://github.com/material-table-core/core/blob/master/__tests__/demo/demo-components/index.js#L982